### PR TITLE
Add shorthand methods to edit `t.Sequence[flare.Row]`

### DIFF
--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -13,8 +13,7 @@ from flare.exceptions import MissingRequiredParameterError, SerializerError
 from flare.internal import bootstrap
 
 if t.TYPE_CHECKING:
-    from flare import context
-    from flare import row
+    from flare import context, row
 
 __all__: t.Final[t.Sequence[str]] = ("Component", "SupportsCookie", "CallbackComponent")
 

--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -170,6 +170,13 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
     def get_me(self: CallbackComponentT, rows: t.Sequence[row.Row]) -> t.Sequence[CallbackComponentT]:
         """
         Return all instances of this component that appear in :typing.Sequence[flare.row.Row]:.
+
+        Args:
+            rows:
+                The rows to search through.
+        Returns:
+            A list of all components of this type that appear in `rows`.
+
         """
         out: list[CallbackComponentT] = []
         for row in rows:
@@ -200,6 +207,12 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
                     # Rows must be passed back into `edit_response`
                     components=rows,
                 )
+
+        Args:
+            rows:
+                The rows to edit.
+        Returns:
+            A list of all components of this type that appear in `rows`.
         """
         mes = self.get_me(rows)
         for me in mes:

--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -171,7 +171,7 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
             ) -> None:
                 rows = ctx.get_components()
                 # Edit this button in the array `rows`
-                counter_button.edit_me(rows, n=n+1)
+                counter_button.set_in(rows, n=n+1)
                 await ctx.edit_response(
                     # Rows must be passed back into `edit_response`
                     components=rows,

--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -182,7 +182,7 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
         self: CallbackComponentT, rows: t.Sequence[row.Row], *args: P.args, **kwargs: P.kwargs
     ) -> t.Sequence[CallbackComponentT]:
         """
-        Edit a all instances of this component in-place in :typing.Sequence[flare.row.Row]:.
+        Edit all instances of this component in-place in :typing.Sequence[flare.row.Row]:.
 
         .. code-block:: python
 

--- a/flare/components/base.py
+++ b/flare/components/base.py
@@ -169,13 +169,13 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
 
     def get_me(self: CallbackComponentT, rows: t.Sequence[row.Row]) -> t.Sequence[CallbackComponentT]:
         """
-        Return all instances of this component that appear in :typing.Sequence[flare.row.Row]:.
+        Return all instances of this component that appear in :class:`typing.Sequence[flare.row.Row]`.
 
         Args:
             rows:
                 The rows to search through.
         Returns:
-            A list of all components of this type that appear in `rows`.
+            A list of all components of this type that appear in ``rows``.
 
         """
         out: list[CallbackComponentT] = []
@@ -189,7 +189,7 @@ class CallbackComponent(Component, SupportsCookie, t.Generic[P]):
         self: CallbackComponentT, rows: t.Sequence[row.Row], *args: P.args, **kwargs: P.kwargs
     ) -> t.Sequence[CallbackComponentT]:
         """
-        Edit all instances of this component in-place in :typing.Sequence[flare.row.Row]:.
+        Edit all instances of this component in-place in :class:`typing.Sequence[flare.row.Row]`.
 
         .. code-block:: python
 

--- a/flare/row.py
+++ b/flare/row.py
@@ -58,6 +58,7 @@ class Row(hikari.api.ComponentBuilder, t.MutableSequence[Component]):
 
         for action_row in message.components:
             assert isinstance(action_row, hikari.ActionRowComponent)
+            rows.append(Row())
 
             for component in action_row.components:
                 if isinstance(component, hikari.ButtonComponent) and component.style is hikari.ButtonStyle.LINK:


### PR DESCRIPTION
I think this is required to make editing more ergonomic.
This will be explained much more in the state section of the docs.

```python
import flare

@flare.button(label="Click me!")
async def counter_button(
    ctx: flare.Context,
    n: int = 0,
) -> None:
    rows = ctx.get_components()
    # Edit this button in the array `rows`
    counter_button.edit_me(rows, n=n+1)
    await ctx.edit_response(
        # Rows must be passed back into `edit_response`
        components=rows,
    )
```
Should it only edit the kwargs your provide? How would that work with param spec?
