### PR TITLE
Unique IDs for buttons with identical parameters

### DIFF
--- a/flare/context.py
+++ b/flare/context.py
@@ -236,7 +236,7 @@ class Context:
         """Returns the flare components for the interaction this context is proxying"""
         return await row.Row.from_message(self.message)
 
-    async def iter_components(self) -> t.AsyncIterable[tuple[int, int, components.Component]]:
+    async def enumerate_components(self) -> t.AsyncIterable[tuple[int, int, components.Component]]:
         """
         Function to iterate through all the components and their row number and column number.
 
@@ -245,7 +245,7 @@ class Context:
             # `row` is the x coordinate.
             # `column` is the y coordinate.
 
-            async for row, column, component in ctx.iter_components():
+            async for row, column, component in ctx.enumerate_components():
                 ...
         """
         for row_number, row in enumerate(await self.get_components()):

--- a/flare/context.py
+++ b/flare/context.py
@@ -6,7 +6,7 @@ import typing as t
 import hikari
 from hikari.snowflakes import Snowflake
 
-from flare import row
+from flare import row, components
 
 __all__: t.Sequence[str] = ("Context", "InteractionResponse")
 
@@ -235,6 +235,19 @@ class Context:
     async def get_components(self) -> t.MutableSequence[row.Row]:
         """Returns the flare components for the interaction this context is proxying"""
         return await row.Row.from_message(self.message)
+
+    async def iter_components(self) -> t.AsyncIterable[tuple[int, int, components.Component]]:
+        """
+        Function to iterate through all the components and their x and y coordinate.
+
+        .. code-block:: python
+
+            async for x, y, component in ctx.iter_components():
+                ...
+        """
+        for x, row in enumerate(await self.get_components()):
+            for y, component in enumerate(row):
+                yield (x, y, component)
 
     async def get_last_response(self) -> InteractionResponse:
         """Get the last response issued to the interaction this context is proxying.

--- a/flare/context.py
+++ b/flare/context.py
@@ -238,16 +238,19 @@ class Context:
 
     async def iter_components(self) -> t.AsyncIterable[tuple[int, int, components.Component]]:
         """
-        Function to iterate through all the components and their x and y coordinate.
+        Function to iterate through all the components and their column number and row now.
 
         .. code-block:: python
 
-            async for x, y, component in ctx.iter_components():
+            # `column` is the x coordinate.
+            # `row` is the y coordinate.
+
+            async for column, row, component in ctx.iter_components():
                 ...
         """
-        for x, row in enumerate(await self.get_components()):
-            for y, component in enumerate(row):
-                yield (x, y, component)
+        for column_number, row in enumerate(await self.get_components()):
+            for row_number, component in enumerate(row):
+                yield (column_number, row_number, component)
 
     async def get_last_response(self) -> InteractionResponse:
         """Get the last response issued to the interaction this context is proxying.

--- a/flare/context.py
+++ b/flare/context.py
@@ -6,7 +6,7 @@ import typing as t
 import hikari
 from hikari.snowflakes import Snowflake
 
-from flare import row, components
+from flare import components, row
 
 __all__: t.Sequence[str] = ("Context", "InteractionResponse")
 

--- a/flare/context.py
+++ b/flare/context.py
@@ -238,19 +238,19 @@ class Context:
 
     async def iter_components(self) -> t.AsyncIterable[tuple[int, int, components.Component]]:
         """
-        Function to iterate through all the components and their column number and row now.
+        Function to iterate through all the components and their row number and column number.
 
         .. code-block:: python
 
-            # `column` is the x coordinate.
-            # `row` is the y coordinate.
+            # `row` is the x coordinate.
+            # `column` is the y coordinate.
 
-            async for column, row, component in ctx.iter_components():
+            async for row, column, component in ctx.iter_components():
                 ...
         """
-        for column_number, row in enumerate(await self.get_components()):
-            for row_number, component in enumerate(row):
-                yield (column_number, row_number, component)
+        for row_number, row in enumerate(await self.get_components()):
+            for column_number, component in enumerate(row):
+                yield (row_number, column_number, component)
 
     async def get_last_response(self) -> InteractionResponse:
         """Get the last response issued to the interaction this context is proxying.

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -202,8 +202,6 @@ class Serde(SerdeABC):
 
         cookie, *args = self.split_on_sep(self.unescape(custom_id))
 
-        print(cookie, *args)
-
         component_ = map.get(self.tuple_list_to_string(cookie))
 
         if component_ is None:

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -60,6 +60,8 @@ class Serde(SerdeABC):
         self._NULL: str = null
         self._VER: int | None = version
 
+        self._increment = 0
+
         if len(sep) != 1:
             raise ValueError("Separator must be a single character.")
 
@@ -91,6 +93,13 @@ class Serde(SerdeABC):
         If None, the serializer will not attempt to verify the version of the serialized data.
         """
         return self._VER
+
+    async def get_inc(self) -> str:
+        self._increment += 1
+        if self._increment > 65535:
+            self._increment = 0
+
+        return await get_converter(int).to_str(self._increment)
 
     def escape(self, string: str) -> str:
         """Escape a string using `self.ESC`, `self.NULL` and `self.SEP`."""

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -60,12 +60,12 @@ class Serde(SerdeABC):
             The character used to signify `None`.
         esc:
             The escape character.
-        version:
-            The serializer version number.
         increment_length:
             `increment` is a unique number to allow buttons for the same values in the same
             message. `increment_length` can be set to `0` if identical buttons are never used
             in the same message.
+        version:
+            The serializer version number.
     """
 
     def __init__(

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -129,7 +129,12 @@ class Serde(SerdeABC):
             converter = get_converter(v)
             return self.escape(await converter.to_str(val)) if val is not None else self.NULL
 
-        out = self.SEP.join((f"{version}{cookie}", *await gather_iter(serialize_one(k, v) for k, v in types.items())))
+        out = self.SEP.join(
+            (
+                f"{self.escape(version)}{self.escape(cookie)}",
+                *await gather_iter(serialize_one(k, v) for k, v in types.items()),
+            )
+        )
 
         if len(out) > 100:
             raise SerializerError(
@@ -196,6 +201,8 @@ class Serde(SerdeABC):
             custom_id = custom_id[1:]
 
         cookie, *args = self.split_on_sep(self.unescape(custom_id))
+
+        print(cookie, *args)
 
         component_ = map.get(self.tuple_list_to_string(cookie))
 

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -126,8 +126,7 @@ class Serde(SerdeABC):
         async def serialize_one(k: str, v: t.Any) -> str:
             val = kwargs.get(k)
             converter = get_converter(v)
-            val = await converter.to_str(val) if val is not None else self.NULL
-            return self.escape(val)
+            return self.escape(await converter.to_str(val)) if val is not None else self.NULL
 
         out = self.SEP.join((f"{version}{cookie}", *await gather_iter(serialize_one(k, v) for k, v in types.items())))
 
@@ -207,7 +206,7 @@ class Serde(SerdeABC):
 
         for k, arg in zip(types.keys(), args):
             if len(arg) == 1:
-                if arg[0] == (self.NULL, True):
+                if arg[0] == (self.NULL, False):
                     transformed_args[k] = None
                     continue
             transformed_args[k] = self.tuple_list_to_string(arg)

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -81,9 +81,6 @@ class Serde(SerdeABC):
         self._NULL: str = null
         self._VER: int | None = version
 
-        # Unique number for all components. These numbers are repeated after 2^16
-        # but that is ok because it is unrealilistic to run into conflicts in one
-        # message.
         self._increment_length = increment_length
         self._increment = 0
 

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -93,6 +93,7 @@ class Serde(SerdeABC):
         return self._VER
 
     def escape(self, string: str) -> str:
+        """Escape a string using `self.ESC`, `self.NULL` and `self.SEP`."""
         out: list[str] = []
         for char in string:
             if char in [self.ESC, self.NULL, self.SEP]:
@@ -102,7 +103,7 @@ class Serde(SerdeABC):
         return "".join(out)
 
     def unescape(self, string: str) -> list[tuple[str, bool]]:
-        """Returns a list of all characters in the string"""
+        """Returns a list of tuples signifying (the character, whether it was escaped)"""
         out: list[tuple[str, bool]] = []
         last_was_esc = False
 
@@ -161,6 +162,7 @@ class Serde(SerdeABC):
 
     @staticmethod
     def tuple_list_to_string(string: list[tuple[str, bool]]) -> str:
+        """Conbine a list of tuples into a string, ignoring the second value."""
         out: list[str] = []
         for char, _ in string:
             out.append(char)

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -85,16 +85,6 @@ class Serde(SerdeABC):
         return self._NULL
 
     @property
-    def ESC_NULL(self) -> str:
-        """The escape sequence for the null character."""
-        return f"{self.ESC}{self.NULL}"
-
-    @property
-    def ESC_SEP(self) -> str:
-        """The escape sequence for the separator."""
-        return f"{self.ESC}{self.SEP}"
-
-    @property
     def VER(self) -> int | None:
         """
         The version of the serialization format.
@@ -102,24 +92,54 @@ class Serde(SerdeABC):
         """
         return self._VER
 
+    def escape(self, string: str) -> str:
+        out: list[str] = []
+        for char in string:
+            if char in [self.ESC, self.NULL, self.SEP]:
+                out.append(f"{self.ESC}{char}")
+            else:
+                out.append(char)
+        return "".join(out)
+
+    def unescape(self, string: str) -> list[tuple[str, bool]]:
+        """Returns a list of all characters in the string"""
+        out: list[tuple[str, bool]] = []
+        last_was_esc = False
+
+        for char in string:
+            if not last_was_esc and char != self.ESC:
+                out.append((char, False))
+                continue
+
+            if last_was_esc:
+                out.append((char, True))
+                last_was_esc = False
+                continue
+
+            last_was_esc = True
+
+        return out
+
     async def serialize(self, cookie: str, types: dict[str, t.Any], kwargs: dict[str, t.Any]) -> str:
         version = "" if self.VER is None else await get_converter(int).to_str(self.VER)
 
         async def serialize_one(k: str, v: t.Any) -> str:
             val = kwargs.get(k)
             converter = get_converter(v)
-            val = (await converter.to_str(val)).replace(self.NULL, self.ESC_NULL) if val is not None else self.NULL
-            return f"{val.replace(self.SEP, self.ESC_SEP)}"
+            val = await converter.to_str(val) if val is not None else self.NULL
+            return self.escape(val)
 
         out = self.SEP.join((f"{version}{cookie}", *await gather_iter(serialize_one(k, v) for k, v in types.items())))
 
         if len(out) > 100:
             raise SerializerError(
-                f"The serialized custom_id for component {cookie} may be too long. Try reducing the number of parameters the component takes.\nGot length: {len(out)} Expected length: 100 or less"
+                f"The serialized custom_id for component {cookie} may be too long."
+                " Try reducing the number of parameters the component takes."
+                f" Got length: {len(out)} Expected length: 100 or less"
             )
         return out
 
-    def split_on_sep(self, string: str) -> list[str]:
+    def split_on_sep(self, string: list[tuple[str, bool]]) -> list[list[tuple[str, bool]]]:
         """Split the provided string on the separator, but ignore separators that are escaped.
 
         Args:
@@ -130,20 +150,30 @@ class Serde(SerdeABC):
             list[str]
                 The split string.
         """
-        out: list[list[str]] = [[string[0]]]
+        out: list[list[tuple[str, bool]]] = [[]]
 
-        for last, char in zip(string[:-1], string[1:]):
-            if last != self.ESC and char == self.SEP:
+        for char, is_escaped in string:
+            if char == self.SEP and not is_escaped:
                 out.append([])
             else:
-                out[-1] += [char]
+                out[-1].append((char, is_escaped))
 
-        return ["".join(row).replace(self.ESC_SEP, self.SEP) for row in out]
+        return out
 
-    async def _cast_kwargs(self, kwargs: dict[str, t.Any], types: dict[str, t.Any]) -> dict[str, t.Any]:
+    @staticmethod
+    def tuple_list_to_string(string: list[tuple[str, bool]]) -> str:
+        out: list[str] = []
+        for char, _ in string:
+            out.append(char)
+        return "".join(out)
+
+    async def cast_kwargs(self, kwargs: dict[str, t.Any], types: dict[str, t.Any]) -> dict[str, t.Any]:
         ret: dict[str, t.Any] = {}
 
-        async def convert_one(k: str, v: t.Any):
+        async def convert_one(k: str, v: t.Any) -> None:
+            if v is None:
+                ret[k] = None
+                return
             cast_to = types[k]
             ret[k] = await get_converter(cast_to).from_str(v)
 
@@ -164,9 +194,9 @@ class Serde(SerdeABC):
 
             custom_id = custom_id[1:]
 
-        cookie, *args = self.split_on_sep(custom_id)
+        cookie, *args = self.split_on_sep(self.unescape(custom_id))
 
-        component_ = map.get(cookie)
+        component_ = map.get(self.tuple_list_to_string(cookie))
 
         if component_ is None:
             raise SerializerError(f"Component with cookie {cookie} does not exist.")
@@ -176,8 +206,10 @@ class Serde(SerdeABC):
         transformed_args: dict[str, t.Any] = {}
 
         for k, arg in zip(types.keys(), args):
-            if arg != self.NULL:
-                arg = arg.replace(self.ESC_NULL, self.NULL)
-                transformed_args[k] = arg
+            if len(arg) == 1:
+                if arg[0] == (self.NULL, True):
+                    transformed_args[k] = None
+                    continue
+            transformed_args[k] = self.tuple_list_to_string(arg)
 
-        return (component_, await self._cast_kwargs(transformed_args, types))
+        return (component_, await self.cast_kwargs(transformed_args, types))

--- a/flare/internal/serde.py
+++ b/flare/internal/serde.py
@@ -73,7 +73,7 @@ class Serde(SerdeABC):
         sep: str = "\x81",
         null: str = "\x82",
         esc: str = "\\",
-        increment_length: int = 4,
+        increment_length: int = 3,
         version: int | None = 0,
     ) -> None:
         self._SEP: str = sep
@@ -234,7 +234,6 @@ class Serde(SerdeABC):
 
             custom_id = custom_id[1:]
 
-        # Remove the increment
         custom_id = custom_id[self._increment_length :]
 
         cookie, *args = self.split_on_sep(self.unescape(custom_id))


### PR DESCRIPTION
This feature is useful because it is not that uncommon to have identical buttons. This also adds a new iterator `ctx.iter_components` that iterates though a message's components with x and y so users do not need to store that manually. I am not completely sure this feature is needed.

This implementation uses 3 bytes. Users can lower this to 0 if they do not intend to repeat custom IDs.