### PR TITLE
Add `type` property to `Row`

### DIFF
--- a/flare/row.py
+++ b/flare/row.py
@@ -98,6 +98,10 @@ class Row(hikari.api.ComponentBuilder, t.MutableSequence[Component[hikari.api.Me
 
         return row.build()
 
+    @property
+    def type(self) -> t.Literal[hikari.ComponentType.ACTION_ROW]:
+        return hikari.ComponentType.ACTION_ROW
+
     def insert(self, index: int, value: Component[hikari.api.MessageActionRowBuilder]) -> None:
         self.__check_width(value)
         self._components.insert(index, value)


### PR DESCRIPTION
An abstract `type` property was added to `hikari.api.ComponentBuilder` in [hikari 2.0.0.dev117](https://github.com/hikari-py/hikari/releases/tag/2.0.0.dev117).

This fixes compatibility with hikari 2.0.0.dev117, as far as I can tell. I've tested this branch on one of my projects successfully.