### PR TITLE
lock pyright to ==1.1.295

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ def lint(session: nox.Session) -> None:
     session.run("isort", "--check", *SCRIPT_DIRS)
 
 
-@pip_session(".", "pyright")
+@pip_session(".", "pyright==1.1.295")
 def pyright(session: nox.Session) -> None:
     session.run("pyright", *SCRIPT_DIRS)
 


### PR DESCRIPTION
There seems to be a bug on newer versions of pyright. I am locking for now so I can make a new release of flare but I will do a more thorough investigation and make an issue with pyright later.