### PR TITLE
fix flare for latest hikari release(s), fix typing issue

### DIFF
--- a/examples/tictactoe.py
+++ b/examples/tictactoe.py
@@ -69,7 +69,7 @@ def disable_all(rows: t.MutableSequence[flare.Row]):
             component.disabled = True
 
 
-class TicTacToe(flare.Button, label=" "):
+class TicTacToe(flare.Button, label="_"):
     # The column of this component.
     x: int
     # The row of this component.
@@ -84,7 +84,6 @@ class TicTacToe(flare.Button, label=" "):
     turn: bool = False
 
     async def callback(self, ctx: flare.MessageContext):
-
         rows = await ctx.get_components()
 
         if ctx.author != (self.player_1 if self.turn else self.player_2):

--- a/flare/components/button.py
+++ b/flare/components/button.py
@@ -76,23 +76,16 @@ class Button(CallbackComponent):
         if not self.label and not self.emoji:
             raise ComponentError(f"Label and emoji cannot both be empty for button component {self.cookie}.")
 
-        button = action_row.add_button(self.style, self.custom_id)
-
-        if self.label:
-            button.set_label(self.label)
-
+        label = self.label or hikari.UNDEFINED
         emoji: hikari.Emoji | hikari.UndefinedType
         if isinstance(self.emoji, str):
             emoji = hikari.Emoji.parse(self.emoji)
         else:
             emoji = self.emoji or hikari.UNDEFINED
 
-        if self.emoji:
-            button.set_emoji(emoji)
-
-        button.set_is_disabled(self.disabled)
-
-        button.add_to_container()
+        action_row.add_interactive_button(
+            self.style, self.custom_id, emoji=emoji, label=label, is_disabled=self.disabled
+        )
 
 
 class button(FunctionalComponent[Button]):
@@ -192,15 +185,7 @@ class LinkButton(Component[hikari.api.MessageActionRowBuilder]):
         return self.url
 
     def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
-        button = action_row.add_button(hikari.ButtonStyle.LINK, self.url)
-
-        if self.label:
-            button.set_label(self.label)
-
-        if self.emoji:
-            button.set_emoji(self.emoji)
-
-        button.add_to_container()
+        action_row.add_link_button(self.url, emoji=self.emoji or hikari.UNDEFINED, label=self.label or hikari.UNDEFINED)
 
 
 # MIT License

--- a/flare/components/modal.py
+++ b/flare/components/modal.py
@@ -186,27 +186,17 @@ class TextInput(ModalComponent):
 
     def build(self, action_row: hikari.api.ModalActionRowBuilder) -> None:
         """Build and append a flare component to a hikari action row."""
-        text_input = action_row.add_text_input(custom_id=self.custom_id, label=self.label)
 
-        if self.style:
-            text_input.set_style(self.style)
-
-        if self.min_length is not None:
-            text_input.set_min_length(self.min_length)
-
-        if self.max_length is not None:
-            text_input.set_max_length(self.max_length)
-
-        if self.required is not None:
-            text_input.set_required(self.required)
-
-        if self.value is not None:
-            text_input.set_value(self.value)
-
-        if self.placeholder is not None:
-            text_input.set_placeholder(self.placeholder)
-
-        text_input.add_to_container()
+        action_row.add_text_input(
+            self.custom_id,
+            self.label,
+            style=self.style,
+            placeholder=self.placeholder or hikari.UNDEFINED,
+            value=self.value or hikari.UNDEFINED,
+            required=self.required or True,  # default is True
+            min_length=self.min_length or 0,  # default is 0
+            max_length=self.max_length or 4000,  # default is 4000
+        )
 
 
 # MIT License

--- a/flare/components/modal.py
+++ b/flare/components/modal.py
@@ -73,8 +73,19 @@ class Modal(SupportsCallback["ModalContext"], SupportsCookie, t.MutableSequence[
     def __len__(self) -> int:
         return len(self._components)
 
+    @t.overload
     def __setitem__(self, key: int, value: ModalComponent) -> None:
-        self._components[key] = value
+        ...
+
+    @t.overload
+    def __setitem__(self, key: slice, value: t.Iterable[ModalComponent]) -> None:
+        ...
+
+    def __setitem__(self, key: int | slice, value: ModalComponent | t.Iterable[ModalComponent]) -> None:
+        if isinstance(key, slice):
+            self._components[key] = t.cast("t.Iterable[ModalComponent]", value)
+        else:
+            self._components[key] = t.cast("ModalComponent", value)
 
     def __delitem__(self, key: int) -> None:
         del self._components[key]

--- a/flare/components/select.py
+++ b/flare/components/select.py
@@ -85,14 +85,15 @@ class _AbstractSelect(CallbackComponent, abc.ABC):
         self.disabled = disabled
         return self
 
+    def _verify_placeholder(self) -> None:
+        if self.placeholder and len(self.placeholder) > 100:
+            raise ComponentError("Placeholder text must be shorter than 100 characters.")
+
     @abc.abstractmethod
     def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
         """
         Build the select menu into the passed in action row.
         """
-
-        # if self.placeholder and len(self.placeholder) > 100:
-        #     raise ComponentError("Placeholder text must be shorter than 100 characters.")
 
 
 class BaseSelect(_AbstractSelect):
@@ -101,6 +102,7 @@ class BaseSelect(_AbstractSelect):
     """
 
     def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        self._verify_placeholder()
         action_row.add_select_menu(
             self._component_type,
             self.custom_id,
@@ -167,6 +169,8 @@ class TextSelect(_AbstractSelect):
         return hikari.ComponentType.TEXT_SELECT_MENU
 
     def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        self._verify_placeholder()
+
         if not self.options:
             raise ComponentError("Expected one or more options for select menu. Got zero.")
 
@@ -322,6 +326,7 @@ class ChannelSelect(_AbstractSelect):
         return self
 
     def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        self._verify_placeholder()
         action_row.add_channel_menu(
             self.custom_id,
             channel_types=self.channel_types or (),  # default is ()

--- a/flare/components/select.py
+++ b/flare/components/select.py
@@ -85,25 +85,30 @@ class _AbstractSelect(CallbackComponent, abc.ABC):
         self.disabled = disabled
         return self
 
-    def build(self, action_row: hikari.api.MessageActionRowBuilder) -> hikari.api.SelectMenuBuilder[t.Any]:
+    @abc.abstractmethod
+    def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
         """
         Build the select menu into the passed in action row.
         """
-        select = action_row.add_select_menu(self._component_type, self.custom_id)
 
-        if self.placeholder and len(self.placeholder) > 100:
-            raise ComponentError("Placeholder text must be shorter than 100 characters.")
+        # if self.placeholder and len(self.placeholder) > 100:
+        #     raise ComponentError("Placeholder text must be shorter than 100 characters.")
 
-        if self.min_values:
-            select.set_min_values(self.min_values)
-        if self.max_values:
-            select.set_max_values(self.max_values)
-        if self.disabled:
-            select.set_is_disabled(self.disabled)
-        select.set_placeholder(self.placeholder)
-        select.add_to_container()
 
-        return select
+class BaseSelect(_AbstractSelect):
+    """
+    Class for select menus that don't have any special properties.
+    """
+
+    def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        action_row.add_select_menu(
+            self._component_type,
+            self.custom_id,
+            placeholder=self.placeholder,
+            min_values=self.min_values or 0,  # default is 0
+            max_values=self.max_values or 1,  # default is 1
+            is_disabled=self.disabled or False,  # default is False
+        )
 
 
 class TextSelect(_AbstractSelect):
@@ -161,42 +166,43 @@ class TextSelect(_AbstractSelect):
     def _component_type(self) -> hikari.ComponentType:
         return hikari.ComponentType.TEXT_SELECT_MENU
 
-    def build(
-        self, action_row: hikari.api.MessageActionRowBuilder
-    ) -> hikari.api.special_endpoints.TextSelectMenuBuilder[t.Any]:
-        select: hikari.api.special_endpoints.TextSelectMenuBuilder[t.Any] = super().build(action_row)  # type: ignore
-
-        if self.options:
-            if len(self.options) > 25:
-                raise ComponentError("Cannot create a select menu with more than 25 options.")
-
-            if self.min_values and self.min_values > len(self.options):
-                raise ComponentError("Cannot create a select menu with greater min options than options.")
-
-            if self.max_values and self.max_values > len(self.options):
-                raise ComponentError("Cannot create a select menu with greater max options than options.")
-
-            for option in self.options:
-                if isinstance(option, str):
-                    select.add_option(option, option).add_to_menu()
-                elif isinstance(option, hikari.SelectMenuOption):
-                    opt = select.add_option(option.label, option.value)
-                    if option.description:
-                        opt.set_description(option.description)
-                    if option.emoji:
-                        opt.set_emoji(option.emoji)
-                    if option.is_default:
-                        opt.set_is_default(option.is_default)
-                    opt.add_to_menu()
-                else:
-                    select.add_option(*option).add_to_menu()
-        else:
+    def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        if not self.options:
             raise ComponentError("Expected one or more options for select menu. Got zero.")
 
-        return select
+        if len(self.options) > 25:
+            raise ComponentError("Cannot create a select menu with more than 25 options.")
+
+        if self.min_values and self.min_values > len(self.options):
+            raise ComponentError("Cannot create a select menu with greater min options than options.")
+
+        if self.max_values and self.max_values > len(self.options):
+            raise ComponentError("Cannot create a select menu with greater max options than options.")
+
+        select = action_row.add_text_menu(
+            self.custom_id,
+            placeholder=self.placeholder,
+            min_values=self.min_values or 0,  # default is 0
+            max_values=self.max_values or 1,  # default is 1
+            is_disabled=self.disabled or False,  # default is False
+        )
+
+        for option in self.options:
+            if isinstance(option, str):
+                select.add_option(option, option)
+            elif isinstance(option, hikari.SelectMenuOption):
+                select.add_option(
+                    option.label,
+                    option.value,
+                    description=option.description or hikari.UNDEFINED,
+                    emoji=option.emoji or hikari.UNDEFINED,
+                    is_default=option.is_default,
+                )
+            else:
+                select.add_option(*option)
 
 
-class UserSelect(_AbstractSelect):
+class UserSelect(BaseSelect):
     """
     Class for a user select menu message component.
 
@@ -219,7 +225,7 @@ class UserSelect(_AbstractSelect):
         return hikari.ComponentType.USER_SELECT_MENU
 
 
-class RoleSelect(_AbstractSelect):
+class RoleSelect(BaseSelect):
     """
     Class for a role select menu message component.
 
@@ -242,7 +248,7 @@ class RoleSelect(_AbstractSelect):
         return hikari.ComponentType.ROLE_SELECT_MENU
 
 
-class MentionableSelect(_AbstractSelect):
+class MentionableSelect(BaseSelect):
     """
     Class for a mentionable select menu message component.
 
@@ -315,15 +321,15 @@ class ChannelSelect(_AbstractSelect):
         self.channel_types = channel_types
         return self
 
-    def build(
-        self, action_row: hikari.api.MessageActionRowBuilder
-    ) -> hikari.api.special_endpoints.ChannelSelectMenuBuilder[t.Any]:
-        select: hikari.api.special_endpoints.ChannelSelectMenuBuilder[t.Any] = super().build(action_row)  # type: ignore
-
-        if self.channel_types:
-            select.set_channel_types(self.channel_types)
-
-        return select
+    def build(self, action_row: hikari.api.MessageActionRowBuilder) -> None:
+        action_row.add_channel_menu(
+            self.custom_id,
+            channel_types=self.channel_types or (),  # default is ()
+            placeholder=self.placeholder or hikari.UNDEFINED,
+            min_values=self.min_values or 0,  # default is 0
+            max_values=self.max_values or 1,  # default is 1
+            is_disabled=self.disabled or False,
+        )
 
     @property
     def _component_type(self) -> hikari.ComponentType:

--- a/flare/row.py
+++ b/flare/row.py
@@ -40,9 +40,21 @@ class Row(hikari.api.ComponentBuilder, t.MutableSequence[Component[hikari.api.Me
     def __len__(self) -> int:
         return len(self._components)
 
-    def __setitem__(self, key: int, value: Component[hikari.api.MessageActionRowBuilder]) -> None:
-        self.__check_width(value)
-        self._components[key] = value
+    def __setitem__(
+        self,
+        key: int | slice,
+        value: Component[hikari.api.MessageActionRowBuilder]
+        | t.Iterable[Component[hikari.api.MessageActionRowBuilder]],
+    ) -> None:
+        if isinstance(key, int):
+            value = t.cast("Component[hikari.api.MessageActionRowBuilder]", value)
+            self.__check_width(value)
+            self._components[key] = value
+        else:
+            value = t.cast("t.Iterable[Component[hikari.api.MessageActionRowBuilder]]", value)
+            for v in value:
+                self.__check_width(v)
+            self._components[key] = value
 
     def __delitem__(self, key: int) -> None:
         del self._components[key]


### PR DESCRIPTION
Loses the `placholder` length check for select menus. Could be re-added.

Tested with `basic.py` and `tictactoe.py` examples, works afaict. Pyright fails because of something unrelated, I think.